### PR TITLE
update littlefs2-sys bindgen dependency to 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false }
+bindgen = { version = "0.56.0" }
 cc = "1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0" }
+bindgen = { version = "0.60", default-features = false }
 cc = "1"
 
 [features]


### PR DESCRIPTION
Per https://github.com/rust-lang/rust-bindgen/issues/2030, this seems to interact poorly with other bindgen dependents that also specify `features = ["runtime"]` (and perhaps other dependents that don't specify `default-features = "false"` at all).