### PR TITLE
Nathan/jsw 41652

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false }
+bindgen = { version = "0.60", default-features = false }
 cc = "1"
 
 [features]

--- a/README.june
+++ b/README.june
@@ -1,0 +1,13 @@
+Updated the littlefs submodule which was tracking this:
+    (HEAD detached at 4c9146e)
+
+This is version v2.2.1 of littlefs (April 9th 2020)
+
+
+to another detached head:
+
+    HEAD detached at 6a53d76
+
+This is both the current head of the master branch and the official v2.5.1
+release (Nov 10th 2022).
+


### PR DESCRIPTION
This updates the littlefs submodule to track v2.5.1.  It was tracking v2.2.1.  

This PR requires a change to the littlefs2 repo (to handle a missing initializer).  This is also tracked as nathan/JSW-41652.