### PR TITLE
support esp32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ repository = "https://github.com/nickray/littlefs2-sys"
 [dependencies]
 cty = "0.2.1"
 
+[target.'cfg(target_os = "espidf")'.dependencies]
+esp-idf-sys = { version = "0.31" }
+
 [build-dependencies]
-bindgen = { version = "0.60", default-features = false }
+bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 cc = "1"
+embuild = { version = "0.30", features = ["espidf"] }
 
 [features]
 assertions = []

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use embuild::cmd::Cmd;
 use std::env;
 use std::path::PathBuf;
 
@@ -12,8 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .flag("-DLFS_NO_ERROR")
         .file("littlefs/lfs.c")
         .file("littlefs/lfs_util.c")
-        .file("string.c")
-    ;
+        .file("string.c");
 
     #[cfg(not(feature = "assertions"))]
     let builder = builder.flag("-DLFS_NO_ASSERT");
@@ -23,14 +23,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     builder.compile("lfs-sys");
 
-    let bindings = bindgen::Builder::default()
+    let mut builder = bindgen::Builder::default()
         .header("littlefs/lfs.h")
         .clang_arg(format!("--target={}", target))
         .use_core()
         .ctypes_prefix("cty")
-        .rustfmt_bindings(true)
-        .generate()
-        .expect("Unable to generate bindings");
+        .rustfmt_bindings(true);
+
+    let target = env::var("TARGET").unwrap();
+
+    if target == "xtensa-esp32s3-espidf" {
+        let mut cmd = Cmd::new("xtensa-esp32s3-elf-ld");
+        cmd.arg("--print-sysroot");
+        let sysroot = cmd
+            .stdout()
+            .map(PathBuf::from)
+            .expect("Failed to find sysroot");
+
+        builder = builder.clang_arg(format!("--sysroot={}", sysroot.display()));
+        // TODO: determine why it isn't sufficient to just set the sysroot.
+        builder = builder.clang_arg(format!("-I{}", sysroot.join("include").display()))
+    }
+
+    let bindings = builder.generate().expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings


### PR DESCRIPTION
A few things:

* cargo-cult the esp-idf-sys and embuild dependencies from other crates that build for xtensa targets;
* add the `runtime` feature to bindgen (so it's enabled when littlefs2-sys is built in isolation);
* add the sysroot/include directory to clang args when generating bindings in order to find header files like string.h.

These changes enable me to build littlefs2-sys in isolation for esp32s3 on both my macOS host and in an Ubuntu Docker container (running on the macOS host). It should probably be made more general, as right now it's specific to esp32s3 rather than esp32*.

As well, some version of these changes could probably be upstreamed to fix https://github.com/nickray/littlefs2/issues/18 (which is filed in the littlefs2 project although it probably needs to be fixed in littlefs2-sys), but a look at https://github.com/nickray/littlefs2-sys/pulls makes me wonder if the project is being actively maintained anymore.